### PR TITLE
feat(ISS-000): responsive+perf mf-sp — tablas, overflow, federation skip, tests

### DIFF
--- a/federation.config.js
+++ b/federation.config.js
@@ -17,12 +17,88 @@ module.exports = withNativeFederation({
   },
 
   skip: [
+    // RxJS subpaths (nunca compartir, causan conflictos de instancia)
     'rxjs/ajax',
     'rxjs/fetch',
     'rxjs/testing',
     'rxjs/webSocket',
+    // NUNCA skipear 'rxjs/operators': Angular lo importa y DEBE compartirse via federation.
+
+    // Angular common subpaths no-estándar
     '@angular/common/http/http',
     '@angular/common/http/upgrade',
+
+    // Angular CDK — todos los subpaths conocidos
+    '@angular/cdk',
+    '@angular/cdk/accordion',
+    '@angular/cdk/bidi',
+    '@angular/cdk/clipboard',
+    '@angular/cdk/coercion',
+    '@angular/cdk/collections',
+    '@angular/cdk/dialog',
+    '@angular/cdk/drag-drop',
+    '@angular/cdk/keycodes',
+    '@angular/cdk/layout',
+    '@angular/cdk/listbox',
+    '@angular/cdk/menu',
+    '@angular/cdk/observers',
+    '@angular/cdk/overlay',
+    '@angular/cdk/platform',
+    '@angular/cdk/portal',
+    '@angular/cdk/scrolling',
+    '@angular/cdk/stepper',
+    '@angular/cdk/table',
+    '@angular/cdk/text-field',
+    '@angular/cdk/tree',
+    '@angular/cdk/testing',
+
+    // Angular Material
+    '@angular/material',
+
+    // Charts y visualización (no usados en mf-sp actualmente, pero presentes en canon)
+    'echarts',
+    'echarts/core',
+    'echarts/charts',
+    'echarts/components',
+    'echarts/renderers',
+    'echarts/features',
+    'ngx-echarts',
+    'chart.js',
+    'apexcharts',
+    'ng-apexcharts',
+
+    // PDF / Office
+    'jspdf',
+    'jspdf-autotable',
+    'xlsx',
+    'file-saver',
+
+    // QR / Barcodes / Imágenes
+    'qrcode',
+    'pngjs',
+    'jsbarcode',
+    'dijkstrajs',
+
+    // Maps
+    'leaflet',
+    '@asymmetrik/ngx-leaflet',
+
+    // Código / Syntax highlight
+    'prismjs',
+
+    // Clipboard
+    'clipboard',
+
+    // Firebase
+    'firebase',
+    'firebase/app',
+    'firebase/messaging',
+    'firebase/analytics',
+    '@angular/fire',
+    '@angular/fire/compat',
+
+    // HTTP clients alternativos
+    'axios',
   ],
 
   sharedMappings: [],

--- a/src/app/portals/admin/accounts/accounts-list.component.spec.ts
+++ b/src/app/portals/admin/accounts/accounts-list.component.spec.ts
@@ -62,4 +62,25 @@ describe('AccountsListComponent', () => {
     fixture.detectChanges();
     expect(fixture.componentInstance.isLoading()).toBeFalse();
   });
+
+  // ─── Regresión responsive (ISS-000) ─────────────────────────────
+  // Verifica que el wrapper de tabla usa overflow-x:auto, no overflow:hidden,
+  // para evitar scroll horizontal en la página en móvil (360-430px).
+  it('[responsive] accounts-table-wrapper should not use overflow:hidden', () => {
+    const fixture = TestBed.createComponent(AccountsListComponent);
+    fixture.detectChanges();
+    const nativeEl = fixture.nativeElement as HTMLElement;
+    const wrapper = nativeEl.querySelector('.accounts-table-wrapper') as HTMLElement | null;
+    expect(wrapper).withContext('accounts-table-wrapper debe existir cuando hay cuentas').toBeTruthy();
+    // overflow:hidden en contenedor de tabla causa scroll de página en móvil.
+    expect(getComputedStyle(wrapper!).overflow).not.toBe('hidden');
+  });
+
+  it('[responsive] accounts-table should be inside the scrollable wrapper', () => {
+    const fixture = TestBed.createComponent(AccountsListComponent);
+    fixture.detectChanges();
+    const wrapper = (fixture.nativeElement as HTMLElement).querySelector('.accounts-table-wrapper');
+    const table = wrapper?.querySelector('table.accounts-table');
+    expect(table).withContext('la tabla debe ser descendiente del wrapper con scroll').toBeTruthy();
+  });
 });

--- a/src/app/portals/admin/accounts/accounts-list.component.ts
+++ b/src/app/portals/admin/accounts/accounts-list.component.ts
@@ -114,7 +114,7 @@ import { FinancialAccount } from '@domain/models/financial-account.model';
     .accounts-table-wrapper {
       background: white;
       border-radius: 12px;
-      overflow: hidden;
+      overflow-x: auto;
       box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
     }
 

--- a/src/app/portals/admin/pages/onboarding/onboarding-list.component.ts
+++ b/src/app/portals/admin/pages/onboarding/onboarding-list.component.ts
@@ -243,7 +243,7 @@ const ONBOARDING_STEPS_TOTAL = 5;
     .table-wrapper {
       background: white;
       border-radius: 12px;
-      overflow: hidden;
+      overflow-x: auto;
       box-shadow: 0 1px 4px rgba(0,0,0,0.08);
     }
 

--- a/src/app/portals/admin/pages/organizations/organizations-list.component.ts
+++ b/src/app/portals/admin/pages/organizations/organizations-list.component.ts
@@ -228,7 +228,7 @@ import {
     .table-wrapper {
       background: white;
       border-radius: 12px;
-      overflow: hidden;
+      overflow-x: auto;
       box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
       margin-bottom: 16px;
     }

--- a/src/app/portals/admin/pages/transfers/global-transfers.component.ts
+++ b/src/app/portals/admin/pages/transfers/global-transfers.component.ts
@@ -258,7 +258,7 @@ interface TransferSummary {
     .table-wrapper {
       background: white;
       border-radius: 12px;
-      overflow: hidden;
+      overflow-x: auto;
       box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
       margin-bottom: 16px;
     }

--- a/src/app/portals/business/pages/movements/movements-history.component.ts
+++ b/src/app/portals/business/pages/movements/movements-history.component.ts
@@ -281,7 +281,7 @@ import { LedgerEntry } from '../../../../domain/models/ledger-entry.model';
       background: #ffffff;
       border: 1px solid #e5e7eb;
       border-radius: 10px;
-      overflow: hidden;
+      overflow-x: auto;
     }
 
     /* Pagination */

--- a/src/app/portals/business/transfers/transfers-list.component.ts
+++ b/src/app/portals/business/transfers/transfers-list.component.ts
@@ -110,13 +110,19 @@ import { SpeiTransfer } from '@domain/models/transfer.model';
     .transfers-table-wrapper {
       background: white;
       border-radius: 12px;
-      overflow: auto;
+      overflow-x: auto;
+      -webkit-overflow-scrolling: touch;
       box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
     }
 
     .transfers-table {
       width: 100%;
       border-collapse: collapse;
+      min-width: 36rem;
+    }
+
+    @media (min-width: 430px) {
+      .transfers-table { min-width: 0; }
     }
 
     .transfers-table th {

--- a/src/app/portals/personal/pages/movements/personal-movements.component.ts
+++ b/src/app/portals/personal/pages/movements/personal-movements.component.ts
@@ -183,7 +183,7 @@ type FilterType = 'all' | 'credits' | 'debits';
     .table-wrapper {
       background: white;
       border-radius: 12px;
-      overflow: hidden;
+      overflow-x: auto;
       box-shadow: 0 1px 4px rgba(0,0,0,0.07);
     }
 

--- a/src/app/portals/personal/pages/receive-money/receive-money.component.ts
+++ b/src/app/portals/personal/pages/receive-money/receive-money.component.ts
@@ -60,6 +60,7 @@ import { FinancialAccount } from '@domain/models/financial-account.model';
               alt="Codigo QR de tu CLABE - disponible proximamente"
               width="120"
               height="120"
+              loading="lazy"
             />
             <p class="qr-caption">QR proximamente</p>
           </div>

--- a/src/app/shared/components/movements-table/movements-table.component.spec.ts
+++ b/src/app/shared/components/movements-table/movements-table.component.spec.ts
@@ -108,4 +108,32 @@ describe('MovementsTableComponent', () => {
     const entry = makeLedgerEntry({ entry_id: 'e99' });
     expect(component.trackById(0, entry)).toBe('e99');
   });
+
+  // ─── Regresión responsive (ISS-000) ─────────────────────────────
+  // Verifica que el contenedor de tabla tiene overflow-x:auto (no hidden)
+  // y que las tablas están dentro de un wrapper con scroll horizontal.
+  it('[responsive] container should have overflow-x:auto, not overflow:hidden', () => {
+    fixture.componentRef.setInput('entries', [makeLedgerEntry()]);
+    fixture.componentRef.setInput('isLoading', false);
+    fixture.detectChanges();
+    const container = (fixture.nativeElement as HTMLElement).querySelector(
+      '.movements-table-container'
+    ) as HTMLElement | null;
+    expect(container).toBeTruthy();
+    const style = getComputedStyle(container!);
+    // overflow:hidden en un wrapper de tabla causa scroll horizontal en la página.
+    // El valor debe ser 'auto' o 'scroll', nunca 'hidden'.
+    expect(style.overflowX).not.toBe('hidden');
+  });
+
+  it('[responsive] data table should be a descendant of the scrollable container', () => {
+    fixture.componentRef.setInput('entries', [makeLedgerEntry()]);
+    fixture.componentRef.setInput('isLoading', false);
+    fixture.detectChanges();
+    const container = (fixture.nativeElement as HTMLElement).querySelector(
+      '.movements-table-container'
+    );
+    const table = container?.querySelector('table.movements-table');
+    expect(table).toBeTruthy();
+  });
 });

--- a/src/styles.css
+++ b/src/styles.css
@@ -16,3 +16,188 @@ body {
   color: #1e293b;
   background-color: #f8fafc;
 }
+
+/* ═══════════════════════════════════════════════════════════════════
+   Sección B — Utilidades canónicas sp-* (RESPONSIVE-PERF-STANDARD)
+   Breakpoints: xs:360px | sm:430px | md:768px | lg:1024px | xl:1280px
+   ═══════════════════════════════════════════════════════════════════ */
+
+/* ── Tabla responsive ──────────────────────────────────────────────
+   OBLIGATORIO: toda <table> va dentro de <div class="sp-table-wrap">
+   El div hace scroll horizontal; la página nunca hace scroll horizontal.
+   ─────────────────────────────────────────────────────────────────── */
+.sp-table-wrap {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  margin-left: -1rem;
+  margin-right: -1rem;
+}
+
+@media (min-width: 430px) {
+  .sp-table-wrap {
+    margin-left: 0;
+    margin-right: 0;
+    border-radius: 8px;
+    border: 1px solid #e2e8f0;
+  }
+}
+
+.sp-table-wrap table,
+.sp-table-wrap .sp-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+  text-align: left;
+  min-width: 36rem;
+}
+
+@media (min-width: 430px) {
+  .sp-table-wrap table,
+  .sp-table-wrap .sp-table {
+    min-width: 0;
+  }
+}
+
+/* ── Contenedor de página ──────────────────────────────────────────
+   Usar en el div raíz de cada página/componente de ruta.
+   ─────────────────────────────────────────────────────────────────── */
+.sp-page-shell {
+  width: 100%;
+  max-width: 1152px;
+  margin-left: auto;
+  margin-right: auto;
+  padding: 1.5rem 1rem;
+}
+
+@media (min-width: 430px) {
+  .sp-page-shell {
+    padding-left: 1.5rem;
+    padding-right: 1.5rem;
+  }
+}
+
+@media (min-width: 1024px) {
+  .sp-page-shell {
+    padding-left: 2rem;
+    padding-right: 2rem;
+    padding-top: 2rem;
+    padding-bottom: 2rem;
+  }
+}
+
+/* ── Encabezado de página: título + acciones ──────────────────────
+   Apila en móvil (columna), fila en sm+.
+   ─────────────────────────────────────────────────────────────────── */
+.sp-page-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+}
+
+@media (min-width: 430px) {
+  .sp-page-header {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+}
+
+/* ── Fila de botones de acción ────────────────────────────────────
+   flex-col-reverse: en móvil el CTA principal (último en DOM) aparece arriba.
+   En sm+ es fila alineada a la derecha.
+   ─────────────────────────────────────────────────────────────────── */
+.sp-actions-row {
+  display: flex;
+  flex-direction: column-reverse;
+  gap: 0.5rem;
+}
+
+.sp-actions-row button,
+.sp-actions-row a,
+.sp-actions-row .sp-btn {
+  width: 100%;
+  justify-content: center;
+}
+
+@media (min-width: 430px) {
+  .sp-actions-row {
+    flex-direction: row;
+    justify-content: flex-end;
+    gap: 0.75rem;
+  }
+
+  .sp-actions-row button,
+  .sp-actions-row a,
+  .sp-actions-row .sp-btn {
+    width: auto;
+  }
+}
+
+/* ── Grid de formulario responsive ──────────────────────────────────
+   1 columna en móvil, 2 columnas en md+ (768px+).
+   ─────────────────────────────────────────────────────────────────── */
+.sp-form-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+}
+
+@media (min-width: 768px) {
+  .sp-form-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+/* ── Grid de tarjetas responsive ────────────────────────────────────
+   Usar en lugar de grid de columnas fijas.
+   ─────────────────────────────────────────────────────────────────── */
+.sp-card-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+}
+
+@media (min-width: 430px) {
+  .sp-card-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (min-width: 1024px) {
+  .sp-card-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+/* ── Utilidades de overflow seguro ──────────────────────────────────*/
+.sp-truncate {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 100%;
+}
+
+.sp-break-words {
+  word-break: break-word;
+  overflow-wrap: break-word;
+}
+
+/* ── Ocultar/mostrar por breakpoint ─────────────────────────────────*/
+.sp-mobile-only { display: block; }
+
+@media (min-width: 431px) {
+  .sp-mobile-only { display: none !important; }
+}
+
+.sp-hide-mobile { display: none; }
+
+@media (min-width: 431px) {
+  .sp-hide-mobile { display: block; }
+}
+
+.sp-desktop-only { display: none; }
+
+@media (min-width: 1024px) {
+  .sp-desktop-only { display: block; }
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -15,3 +15,197 @@ body {
 .sp-page {
   padding: 24px;
 }
+
+// ─── Breakpoints SuperPago ────────────────────────────────────────
+// Uso: @include mobile { ... }  → ≤430px
+//       @include tablet { ... } → 431px–1023px
+//       @include desktop { ... }→ ≥1024px
+// Siempre diseñar mobile-first: estilos base = móvil, override con tablet/desktop.
+
+$bp-sm:  430px;
+$bp-md:  768px;
+$bp-lg: 1024px;
+$bp-xl: 1280px;
+
+@mixin mobile {
+  @media (max-width: #{$bp-sm}) { @content; }
+}
+
+@mixin tablet {
+  @media (min-width: #{$bp-sm + 1px}) and (max-width: #{$bp-lg - 1px}) { @content; }
+}
+
+@mixin tablet-up {
+  @media (min-width: #{$bp-md}) { @content; }
+}
+
+@mixin desktop {
+  @media (min-width: #{$bp-lg}) { @content; }
+}
+
+@mixin desktop-wide {
+  @media (min-width: #{$bp-xl}) { @content; }
+}
+
+// ─── Sección B CSS-puro — utilidades canónicas sp-* ──────────────
+
+/* xs: 360px | sm: 430px | md: 768px | lg: 1024px | xl: 1280px */
+
+/* ── Tabla responsive ──────────────────────────────────────────────
+   OBLIGATORIO: toda <table> va dentro de <div class="sp-table-wrap">
+   ─────────────────────────────────────────────────────────────────── */
+.sp-table-wrap {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  margin-left: -1rem;
+  margin-right: -1rem;
+}
+
+@media (min-width: 430px) {
+  .sp-table-wrap {
+    margin-left: 0;
+    margin-right: 0;
+    border-radius: 8px;
+    border: 1px solid var(--border-color, #e2e8f0);
+  }
+}
+
+.sp-table-wrap table,
+.sp-table-wrap .sp-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+  text-align: left;
+  min-width: 36rem;
+}
+
+@media (min-width: 430px) {
+  .sp-table-wrap table,
+  .sp-table-wrap .sp-table {
+    min-width: 0;
+  }
+}
+
+/* ── Contenedor de página ──────────────────────────────────────────
+   Usar en el div raíz de cada página/componente de ruta.
+   ─────────────────────────────────────────────────────────────────── */
+.sp-page-shell {
+  width: 100%;
+  max-width: 1152px;
+  margin-left: auto;
+  margin-right: auto;
+  padding: 1.5rem 1rem;
+}
+
+@media (min-width: 430px) {
+  .sp-page-shell {
+    padding-left: 1.5rem;
+    padding-right: 1.5rem;
+  }
+}
+
+@media (min-width: 1024px) {
+  .sp-page-shell {
+    padding-left: 2rem;
+    padding-right: 2rem;
+    padding-top: 2rem;
+    padding-bottom: 2rem;
+  }
+}
+
+/* ── Encabezado de página: título + acciones ──────────────────────
+   Apila en móvil (columna), fila en sm+.
+   ─────────────────────────────────────────────────────────────────── */
+.sp-page-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+}
+
+@media (min-width: 430px) {
+  .sp-page-header {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+}
+
+/* ── Fila de botones de acción ────────────────────────────────────
+   flex-col-reverse: en móvil el CTA principal (último en DOM) aparece arriba.
+   ─────────────────────────────────────────────────────────────────── */
+.sp-actions-row {
+  display: flex;
+  flex-direction: column-reverse;
+  gap: 0.5rem;
+}
+
+.sp-actions-row button,
+.sp-actions-row a,
+.sp-actions-row .sp-btn {
+  width: 100%;
+  justify-content: center;
+}
+
+@media (min-width: 430px) {
+  .sp-actions-row {
+    flex-direction: row;
+    justify-content: flex-end;
+    gap: 0.75rem;
+  }
+
+  .sp-actions-row button,
+  .sp-actions-row a,
+  .sp-actions-row .sp-btn {
+    width: auto;
+  }
+}
+
+/* ── Grid de formulario responsive ──────────────────────────────────
+   1 columna en móvil, 2 columnas en md+ (768px+).
+   ─────────────────────────────────────────────────────────────────── */
+.sp-form-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+}
+
+@media (min-width: 768px) {
+  .sp-form-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+/* ── Grid de tarjetas responsive ────────────────────────────────────
+   Usar en lugar de grid de columnas fijas.
+   ─────────────────────────────────────────────────────────────────── */
+.sp-card-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+}
+
+@media (min-width: 430px) {
+  .sp-card-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (min-width: 1024px) {
+  .sp-card-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+/* ── Utilidades de overflow seguro ──────────────────────────────────*/
+.sp-truncate {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 100%;
+}
+
+.sp-break-words {
+  word-break: break-word;
+  overflow-wrap: break-word;
+}


### PR DESCRIPTION
## Resumen

Aplica el estándar **RESPONSIVE-PERF-STANDARD v1.0** al micro-frontend `mf-sp` (Angular 21 + Native Federation, SCSS puro).

### Cambios aplicados

**Responsive — tablas y overflow**
- `styles.css`: bloque canónico de utilidades `sp-*` (`sp-table-wrap`, `sp-page-shell`, `sp-actions-row`, `sp-form-grid`, `sp-card-grid`) con breakpoints oficiales (xs:360/sm:430/md:768/lg:1024/xl:1280)
- `styles.scss`: mixins SCSS (`mobile`, `tablet`, `tablet-up`, `desktop`, `desktop-wide`) y variables `$bp-*`
- 6 contenedores de tabla: `overflow: hidden` → `overflow-x: auto` para evitar scroll horizontal de página en móvil:
  - `global-transfers.component.ts` (`.table-wrapper`)
  - `onboarding-list.component.ts` (`.table-wrapper`)
  - `organizations-list.component.ts` (`.table-wrapper`)
  - `accounts-list.component.ts` (`.accounts-table-wrapper`)
  - `movements-history.component.ts` (`.table-card`)
  - `personal-movements.component.ts` (`.table-wrapper`)
- `transfers-list.component.ts`: `overflow: auto` → `overflow-x: auto` + `-webkit-overflow-scrolling: touch` + `min-width: 36rem` en tabla (scroll interno, no de página)

**Performance — imágenes**
- `receive-money.component.ts`: `loading="lazy"` en `<img>` que ya tenía `width`/`height` explícitos

**SEO**
- Todas las rutas ya tienen `title:` en `admin.routes.ts`, `business.routes.ts` y `personal.routes.ts` — sin cambios requeridos

**Module Federation**
- `federation.config.js`: lista canónica de `skip` según estándar (Angular CDK, Material, charts, PDF, maps, Firebase, axios). `rxjs/operators` NO skipado (rompe bootstrap dev)

**Tests de regresión responsive**
- `movements-table.component.spec.ts`: 2 tests — verifica `overflow-x` no es `hidden` y tabla está dentro del wrapper
- `accounts-list.component.spec.ts`: 2 tests — verifica mismo contrato en `.accounts-table-wrapper`

## Plan de pruebas

- [ ] `ng build --configuration production` → sin errores (verificado en CI)
- [ ] DevTools 360px: `document.documentElement.scrollWidth === document.documentElement.clientWidth`
- [ ] DevTools 430px: sin scroll horizontal
- [ ] DevTools 768px: layout tablet correcto
- [ ] Tests de regresión: `ng test --watch=false` → verdes

🤖 Generated with [Claude Code](https://claude.com/claude-code)